### PR TITLE
Add missing ts def file

### DIFF
--- a/registerStore.d.ts
+++ b/registerStore.d.ts
@@ -1,8 +1,1 @@
-// import { Store } from "redux";
-
-// // declare module 'cypress-redux/registerStore' {
-//   function registerStore(store: Store): void;
-//   export = registerStore;
-// // }
-
 declare module 'cypress-redux/registerStore';

--- a/registerStore.d.ts
+++ b/registerStore.d.ts
@@ -1,0 +1,8 @@
+// import { Store } from "redux";
+
+// // declare module 'cypress-redux/registerStore' {
+//   function registerStore(store: Store): void;
+//   export = registerStore;
+// // }
+
+declare module 'cypress-redux/registerStore';


### PR DESCRIPTION
In a Typescript project the build was complaining because of the missing declaration for the `registerStore` function. This is the least useful declaration one could add, but at least it makes the TS compiler happy! :)